### PR TITLE
Allow consumer to provide HttpClient instance

### DIFF
--- a/src/Slack.Webhooks.Tests/Properties/AssemblyInfo.cs
+++ b/src/Slack.Webhooks.Tests/Properties/AssemblyInfo.cs
@@ -31,6 +31,7 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.3.28")]
-[assembly: AssemblyFileVersion("0.1.3.28")]
+// [assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyInformationalVersion("1.0.3-httpclient.17+Branch.feature-httpclient.Sha.c11957856f96bd3fe7e0c3bfb9d136eb177f7636")]

--- a/src/Slack.Webhooks.Tests/Slack.Webhooks.Tests.csproj
+++ b/src/Slack.Webhooks.Tests/Slack.Webhooks.Tests.csproj
@@ -40,6 +40,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Slack.Webhooks.Tests/SlackClientShould.cs
+++ b/src/Slack.Webhooks.Tests/SlackClientShould.cs
@@ -1,10 +1,7 @@
 ﻿using Moq;
 using Moq.Protected;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Slack.Webhooks.Tests/SlackClientShould.cs
+++ b/src/Slack.Webhooks.Tests/SlackClientShould.cs
@@ -8,22 +8,22 @@ using Xunit;
 
 namespace Slack.Webhooks.Tests
 {
-    public class SlackClientTests
+    public class SlackClientShould
     {
         [Fact]
-        public void SlackClient_should_throw_exception_if_slack_url_not_given()
+        public void ThrowExceptionWhenUrlIsEmpty()
         {
             Assert.Throws<ArgumentException>(() => new SlackClient(string.Empty));
         }
 
         [Fact]
-        public void SlackClient_should_throw_exception_if_valid_url_not_given()
+        public void ThrowExceptionIfUrlIsMalformed()
         {
             Assert.Throws<ArgumentException>(() => new SlackClient("[/]dodgy_url!@.slack.com"));
         }
 
         [Fact]
-        public void SlackClient_returns_false_if_post_fails()
+        public void ReturnFalseIfPostFails()
         {
             //arrange
             const string webserviceurl = "https://hooks.slack.com/invalid";
@@ -37,10 +37,8 @@ namespace Slack.Webhooks.Tests
             Assert.False(result);
         }
 
-        
-
         [Fact]
-        public void SlackClient_should_remember_timeout()
+        public void RememberTimeout()
         {
             const string webserviceurl = "https://hooks.slack.com/invalid";
             var timeoutSeconds = 2;
@@ -50,7 +48,7 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
-        public void SlackClient_should_reuse_httpclient()
+        public void ReuseHttpClient()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/invalid";

--- a/src/Slack.Webhooks/SlackMessage.cs
+++ b/src/Slack.Webhooks/SlackMessage.cs
@@ -10,6 +10,13 @@ namespace Slack.Webhooks
     /// </summary>
     public class SlackMessage
     {
+        private static readonly DefaultContractResolver resolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() };
+        private static readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        {
+            ContractResolver = resolver,
+            NullValueHandling = NullValueHandling.Ignore
+        };
+
         private bool _markdown = true;
         /// <summary>
         /// This is the text that will be posted to the channel
@@ -104,16 +111,17 @@ namespace Slack.Webhooks
         /// <returns>JSON formatted string</returns>
         public string AsJson()
         {
-            var resolver = new DefaultContractResolver
-            {
-                NamingStrategy = new SnakeCaseNamingStrategy()
-            };
+            return JsonConvert.SerializeObject(this, serializerSettings);
+        }
 
-            return JsonConvert.SerializeObject(this, new JsonSerializerSettings
-            {
-                ContractResolver = resolver,
-                NullValueHandling = NullValueHandling.Ignore
-            });
+        /// <summary>
+        /// Deserialize SlackMessage from a JSON string
+        /// </summary>
+        /// <param name="json">string containing serialized JSON</param>
+        /// <returns>SlackMessage</returns>
+        public static SlackMessage FromJson(string json)
+        {
+            return JsonConvert.DeserializeObject<SlackMessage>(json, serializerSettings);
         }
     }
 }


### PR DESCRIPTION
Adding additional parameter to the SlackClient constructor accepting an instance of HttpClient. Also implementing the IDisposable interface to dispose of instance of HttpClient.

Closes #59 and #60