### PR TITLE
Add support for Slack's Block Kit

### DIFF
--- a/src/Slack.Webhooks.Tests/ActionsBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ActionsBlockFixtures.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Slack.Webhooks.Elements;
+using Slack.Webhooks.Interfaces;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ActionsBlockFixtures
+    {
+        [Fact]
+        public void ShouldSerializeActionElements()
+        {
+            // arrange 
+            var elementList = new List<IActionElement> 
+            { 
+                new Button(), 
+                new SelectChannels(), 
+                new SelectConversations(), 
+                new SelectExternal(), 
+                new SelectStatic(), 
+                new SelectUsers(),
+                new Overflow(),
+                new DatePicker()
+            };
+            var actions = new Actions { Elements = elementList };
+
+            // act
+            var elementListPayload = SlackClient.SerializeObject(elementList);
+            var payload = SlackClient.SerializeObject(actions);
+
+            // assert
+            payload.Should().Contain($"\"elements\":{elementListPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/BlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/BlockFixtures.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Slack.Webhooks.Blocks;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class BlockFixtures
+    {
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void ShouldHaveBlockTypeAndBlockId(Block block, string expectedType, string expectedBlockId)
+        {
+            // arrange/act
+            var payload = SlackClient.SerializeObject(block);
+
+            // assert
+            payload.Should().Contain($"\"type\":\"{expectedType}\"");
+            payload.Should().Contain($"\"block_id\":\"{expectedBlockId}\"");
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            return new List<object[]>
+            {
+                new object[] { new Divider {BlockId = "0001"}, "divider", "0001" },
+                new object[] { new Image {BlockId = "0002"}, "image", "0002" },
+                new object[] { new Section {BlockId = "0003"}, "section", "0003" },
+                new object[] { new Context {BlockId = "0004"}, "context", "0004" },
+                new object[] { new File {BlockId = "0005"}, "file", "0005" },
+                new object[] { new Actions {BlockId = "0006"}, "actions", "0006" },
+                new object[] { new Input {BlockId = "0007"}, "input", "0007" }
+            };
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/ButtonElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ButtonElementFixtures.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ButtonElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var button = new Button();
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"type\":\"button\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeText()
+        {
+            // arrange
+            var button = new Button { Text = new TextObject { Text = "Test Text" }};
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"text\":{\"type\":\"plain_text\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var button = new Button { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeUrl()
+        {
+            // arrange
+            var button = new Button { Url = "http://someurl.com" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"url\":\"http://someurl.com\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeValue()
+        {
+            // arrange
+            var button = new Button { Value = "Value123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"value\":\"Value123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeStyle()
+        {
+            // arrange
+            var button = new Button { Style = "Style123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"style\":\"Style123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation();
+            var button = new Button { Confirm = confirm };
+
+            // act
+            var confirmPayload = SlackClient.SerializeObject(confirm);
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain($"\"confirm\":{confirmPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/ConfirmationElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ConfirmationElementFixtures.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ConfirmationElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeTitle()
+        {
+            // arrange
+            var confirm = new Confirmation { Title = new TextObject { Text = "Title Test"} };
+
+            // act
+            var payload = SlackClient.SerializeObject(confirm);
+
+            // assert
+            payload.Should().Contain("\"title\":{");
+            payload.Should().Contain("\"text\":\"Title Test\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeText()
+        {
+            // arrange
+            var confirm = new Confirmation { Text = new TextObject { Text = "Title Test"} };
+
+            // act
+            var payload = SlackClient.SerializeObject(confirm);
+
+            // assert
+            payload.Should().Contain("\"text\":{");
+            payload.Should().Contain("\"text\":\"Title Test\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation { Confirm = new TextObject { Text = "Title Test"} };
+
+            // act
+            var payload = SlackClient.SerializeObject(confirm);
+
+            // assert
+            payload.Should().Contain("\"confirm\":{");
+            payload.Should().Contain("\"text\":\"Title Test\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeDeny()
+        {
+            // arrange
+            var confirm = new Confirmation { Deny = new TextObject { Text = "Title Test"} };
+
+            // act
+            var payload = SlackClient.SerializeObject(confirm);
+
+            // assert
+            payload.Should().Contain("\"deny\":{");
+            payload.Should().Contain("\"text\":\"Title Test\"");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/ContextBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ContextBlockFixtures.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Slack.Webhooks.Elements;
+using Slack.Webhooks.Interfaces;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ContextBlockFixtures
+    {
+        [Fact]
+        public void ShouldBeAbleToContainImageElements()
+        {
+            // arrange
+            var context = new Context
+            {
+                Elements = new List<IContextElement>() { new Blocks.Image() }
+            };
+
+            // act
+            var payload = SlackClient.SerializeObject(context);
+
+            // assert
+            payload.Should().Contain("\"elements\":["); // bleeugh
+        }
+
+        [Fact]
+        public void ShouldBeAbleToContainTextElements()
+        {
+            // arrange
+            var context = new Context 
+            {
+                Elements = new List<IContextElement>() { new TextObject() }
+            };
+
+            // act
+            var payload = SlackClient.SerializeObject(context);
+
+            // assert
+            payload.Should().Contain("\"elements\":["); // bleeugh
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/DatePickerElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/DatePickerElementFixtures.cs
@@ -1,0 +1,78 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class DatePickerElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var button = new DatePicker();
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"type\":\"datepicker\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var button = new DatePicker { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialDate()
+        {
+            // arrange
+            var button = new DatePicker { InitialDate = "2019-11-01" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"initial_date\":\"2019-11-01\"");
+        }
+
+        [Fact]
+        public void ShouldSerializePlaceholder()
+        {
+            // arrange
+            var text = new TextObject();
+            var button = new DatePicker { Placeholder = text };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(text);
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain($"\"placeholder\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation();
+            var button = new DatePicker { Confirm = confirm };
+
+            // act
+            var confirmPayload = SlackClient.SerializeObject(confirm);
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain($"\"confirm\":{confirmPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/ElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ElementFixtures.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ElementFixtures
+    {
+        [Theory]
+        [MemberData(nameof(GetData))]
+        public void ShouldHaveBlockTypeAndBlockId(Elements.Element element, string expectedType)
+        {
+            // arrange/act
+            var payload = SlackClient.SerializeObject(element);
+
+            // assert
+            payload.Should().Contain($"\"type\":\"{expectedType}\"");
+        }
+
+        public static IEnumerable<object[]> GetData()
+        {
+            return new List<object[]>
+            {
+                new object[] { new Elements.Button(), "button"},
+                new object[] { new Elements.DatePicker(), "datepicker" },
+                new object[] { new Elements.Image(), "image" },
+                new object[] { new Elements.MultiSelectChannels(), "multi_channels_select" },
+                new object[] { new Elements.MultiSelectConversations(), "multi_conversations_select" },
+                new object[] { new Elements.MultiSelectExternal(), "multi_external_select" },
+                new object[] { new Elements.MultiSelectStatic(), "multi_static_select"},
+                new object[] { new Elements.MultiSelectUsers(), "multi_users_select"},
+                new object[] { new Elements.Overflow(), "overflow"},
+                new object[] { new Elements.PlainTextInput(), "plain_text_input"},
+                new object[] { new Elements.RadioButtons(), "radio_buttons"},
+                new object[] { new Elements.SelectChannels(), "channels_select" },
+                new object[] { new Elements.SelectConversations(), "conversations_select" },
+                new object[] { new Elements.SelectExternal(), "external_select" },
+                new object[] { new Elements.SelectStatic(), "static_select"},
+                new object[] { new Elements.SelectUsers(), "users_select"}
+            };
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/FileBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/FileBlockFixtures.cs
@@ -1,0 +1,36 @@
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class FileBlockFixtures
+    {
+        [Fact]
+        public void ShouldHaveExternalId()
+        {
+            // arrange
+            var file = new File { ExternalId = "AB_1234"};
+
+            // act
+            var payload = SlackClient.SerializeObject(file);
+
+            // assert
+            payload.Should().Contain("\"external_id\":\"AB_1234\"");
+        }
+
+        [Fact]
+        public void ShouldHaveRemoteSourceByDefault()
+        {
+            // arrange
+            var file = new File();
+
+            // act
+            var payload = SlackClient.SerializeObject(file);
+
+            // assert
+            file.Source.Should().Be("remote");
+            payload.Should().Contain("\"source\":\"remote\"");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/ImageBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ImageBlockFixtures.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ImageBlockFixtures
+    {
+        [Fact]
+        public void ShouldContainImageUrl()
+        {
+            // arrange
+            var image = new Blocks.Image { ImageUrl = "http://someimage" };
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"image_url\":\"http://someimage\"");
+        }
+
+        [Fact]
+        public void ShouldContainAltText()
+        {
+            // arrange
+            var image = new Blocks.Image { AltText = "The Text" };
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"alt_text\":\"The Text\"");
+        }
+
+        [Fact]
+        public void ShouldContainTitle()
+        {
+            // arrange
+            var image = new Blocks.Image { Title = new TextObject { Text = "The Title"} };
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"text\":\"The Title\"");
+        }
+
+        
+    }
+}

--- a/src/Slack.Webhooks.Tests/ImageElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/ImageElementFixtures.cs
@@ -1,0 +1,48 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class ImageElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var image = new Image();
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"type\":\"image\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeImageUrl()
+        {
+            // arrange
+            var image = new Image { ImageUrl = "http://someurl.com" };
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"image_url\":\"http://someurl.com\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeAltText()
+        {
+            // arrange
+            var image = new Image { AltText = "Alternate Text" };
+
+            // act
+            var payload = SlackClient.SerializeObject(image);
+
+            // assert
+            payload.Should().Contain("\"alt_text\":\"Alternate Text\"");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/InputBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/InputBlockFixtures.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Slack.Webhooks.Elements;
+using Slack.Webhooks.Interfaces;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class InputBlockFixtures
+    {
+        [Fact]
+        public void ShouldSerializeLabel()
+        {
+            // arrange
+            var textObject = new TextObject { Text = "Test label"};
+            var input = new Input { Label = textObject };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(textObject);
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain($"\"label\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeHint()
+        {
+            // arrange
+            var textObject = new TextObject { Text = "Test hint"};
+            var input = new Input { Hint = textObject };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(textObject);
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain($"\"hint\":{textPayload}");
+        }
+        
+        [Fact]
+        public void ShouldSerializeOptional()
+        {
+            // arrange
+            var input = new Input { Optional = true };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"optional\":true");
+        }
+
+        [Theory]
+        [MemberData(nameof(GetInputElementData))]
+        public void ShouldSerializeInputElementTypes(object element)
+        {
+            // arrange
+            var input = new Input { Element = (IInputElement)element };
+
+            // act
+            var elementPayload = SlackClient.SerializeObject(element);
+            var payload = SlackClient.SerializeObject(input);
+
+            // arrange
+            payload.Should().Contain($"\"element\":{elementPayload}");
+        }
+
+        public static IEnumerable<object[]> GetInputElementData()
+        {
+            return new List<object[]>
+            {
+                new object[] { new PlainTextInput() },
+                new object[] { new SelectChannels() },
+                new object[] { new SelectUsers() },
+                new object[] { new SelectConversations() },
+                new object[] { new SelectStatic() },
+                new object[] { new SelectExternal() },
+                new object[] { new MultiSelectChannels() },
+                new object[] { new MultiSelectUsers() },
+                new object[] { new MultiSelectConversations() },
+                new object[] { new MultiSelectStatic() },
+                new object[] { new MultiSelectExternal() },
+                new object[] { new DatePicker() }
+            };
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/MultiSelectExternalElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/MultiSelectExternalElementFixtures.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class MultiSelectExternalElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeMinQueryLength()
+        {
+            // arrange
+            var select = new MultiSelectExternal { MinQueryLength = 5 };
+
+            // act
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"min_query_length\":5");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var select = new MultiSelectExternal { InitialOptions = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_options\":{optionsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/MultiSelectStaticElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/MultiSelectStaticElementFixtures.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class MultiSelectStaticElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var select = new MultiSelectStatic { Options = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"options\":{optionsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var select = new MultiSelectStatic { InitialOptions = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_options\":{optionsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOptionGroup()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var groups = new List<OptionGroup> { new OptionGroup { Options = options }};
+            var select = new MultiSelectStatic { OptionGroups = groups };
+
+            // act
+            var groupsPayload = SlackClient.SerializeObject(groups);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"option_groups\":{groupsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/MultiSelectUsersElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/MultiSelectUsersElementFixtures.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class MultiSelectUsersElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialUsers()
+        {
+            // arrange
+            var options = new List<string> { "User123", "User321" };
+            var select = new MultiSelectUsers { InitialUsers = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_users\":{optionsPayload}");
+        }
+    }
+
+    public class MultiSelectConversationsElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialConversations()
+        {
+            // arrange
+            var options = new List<string> { "Convo123", "Convo321" };
+            var select = new MultiSelectConversations { InitialConversations = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_conversations\":{optionsPayload}");
+        }
+    }
+
+    public class MultiSelectChannelsElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialChannels()
+        {
+            // arrange
+            var options = new List<string> { "Convo123", "Convo321" };
+            var select = new MultiSelectChannels { InitialChannels = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_channels\":{optionsPayload}");
+        }
+    }
+    
+}

--- a/src/Slack.Webhooks.Tests/OptionElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/OptionElementFixtures.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class OptionElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializePlaceholder()
+        {
+            // arrange
+            var text = new TextObject();
+            var option = new Option { Text = text };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(text);
+            var payload = SlackClient.SerializeObject(option);
+
+            // assert
+            payload.Should().Contain($"\"text\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeValue()
+        {
+            // arrange
+            var option = new Option { Value = "Value123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(option);
+
+            // assert
+            payload.Should().Contain("\"value\":\"Value123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeUrl()
+        {
+            // arrange
+            var option = new Option { Url = "http://someurl.com" };
+
+            // act
+            var payload = SlackClient.SerializeObject(option);
+
+            // assert
+            payload.Should().Contain("\"url\":\"http://someurl.com\"");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/OptionGroupElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/OptionGroupElementFixtures.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class OptionGroupElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeLabel()
+        {
+            // arrange
+            var text = new TextObject();
+            var option = new OptionGroup { Label = text };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(text);
+            var payload = SlackClient.SerializeObject(option);
+
+            // assert
+            payload.Should().Contain($"\"label\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "test" }};
+            var group = new OptionGroup { Options = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(group);
+
+            // assert
+            payload.Should().Contain($"\"options\":{optionsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/OverflowElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/OverflowElementFixtures.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class OverflowElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var overflow = new Overflow();
+
+            // act
+            var payload = SlackClient.SerializeObject(overflow);
+
+            // assert
+            payload.Should().Contain("\"type\":\"overflow\"");
+        }
+
+        
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var overflow = new Overflow { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(overflow);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+
+        
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation();
+            var overflow = new Overflow { Confirm = confirm };
+
+            // act
+            var confirmPayload = SlackClient.SerializeObject(confirm);
+            var payload = SlackClient.SerializeObject(overflow);
+
+            // assert
+            payload.Should().Contain($"\"confirm\":{confirmPayload}");
+        }
+        
+        [Fact]
+        public void ShouldSerializeOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var overflow = new Overflow { Options = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(overflow);
+
+            // assert
+            payload.Should().Contain($"\"options\":{optionsPayload}");
+        }
+        
+    }
+}

--- a/src/Slack.Webhooks.Tests/PlainTextInputElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/PlainTextInputElementFixtures.cs
@@ -1,0 +1,102 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class PlainTextInputElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var input = new PlainTextInput();
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"type\":\"plain_text_input\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var input = new PlainTextInput { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+        
+        [Fact]
+        public void ShouldSerializePlaceholder()
+        {
+            // arrange
+            var text = new TextObject();
+            var input = new PlainTextInput { Placeholder = text };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(text);
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain($"\"placeholder\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialValue()
+        {
+            // arrange
+            var input = new PlainTextInput { InitialValue = "Value123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"initial_value\":\"Value123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeMultiLine()
+        {
+            // arrange
+            var input = new PlainTextInput { MultiLine = true };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"multi_line\":true");
+        }
+
+        [Fact]
+        public void ShouldSerializeMinLength()
+        {
+            // arrange
+            var input = new PlainTextInput { MinLength = 10 };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"min_length\":10");
+        }
+
+        [Fact]
+        public void ShouldSerializeMaxLength()
+        {
+            // arrange
+            var input = new PlainTextInput { MaxLength = 10 };
+
+            // act
+            var payload = SlackClient.SerializeObject(input);
+
+            // assert
+            payload.Should().Contain("\"max_length\":10");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/RadioButtonElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/RadioButtonElementFixtures.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class RadioButtonElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeType()
+        {
+            // arrange
+            var radio = new RadioButtons();
+
+            // act
+            var payload = SlackClient.SerializeObject(radio);
+
+            // assert
+            payload.Should().Contain("\"type\":\"radio_buttons\"");
+        }
+
+        
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var radio = new RadioButtons { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(radio);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+
+        
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation();
+            var radio = new RadioButtons { Confirm = confirm };
+
+            // act
+            var confirmPayload = SlackClient.SerializeObject(confirm);
+            var payload = SlackClient.SerializeObject(radio);
+
+            // assert
+            payload.Should().Contain($"\"confirm\":{confirmPayload}");
+        }
+        
+        [Fact]
+        public void ShouldSerializeOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var radio = new RadioButtons { Options = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(radio);
+
+            // assert
+            payload.Should().Contain($"\"options\":{optionsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOption()
+        {
+            // arrange
+            var option = new Option { Value = "Value123" };
+            var radio = new RadioButtons { InitialOption = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(radio);
+
+            // assert
+            payload.Should().Contain($"\"initial_option\":{optionsPayload}");
+        }
+        
+    }
+}

--- a/src/Slack.Webhooks.Tests/SectionBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SectionBlockFixtures.cs
@@ -42,11 +42,11 @@ namespace Slack.Webhooks.Tests
         public void ShouldSerializeAccessory()
         {
             // arrange
-            var accessoryList = new List<Element> { new Button() };
-            var section = new Section { Accessory = accessoryList };
+            var button = new Button();
+            var section = new Section { Accessory = button };
 
             // act
-            var accessoryPayload = SlackClient.SerializeObject(accessoryList);
+            var accessoryPayload = SlackClient.SerializeObject(button);
             var payload = SlackClient.SerializeObject(section);
 
             // assert

--- a/src/Slack.Webhooks.Tests/SectionBlockFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SectionBlockFixtures.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Blocks;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class SectionBlockFixtures
+    {
+        [Fact]
+        public void ShouldSerializeText()
+        {
+            // arrange
+            var textObject = new TextObject { Text = "This is text" };
+            var section = new Section { Text = textObject };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(textObject);
+            var payload = SlackClient.SerializeObject(section);
+
+            // assert
+            payload.Should().Contain($"\"text\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeFields()
+        {
+            // arrange
+            var fieldsList = new List<TextObject> { new TextObject { Text = "This is text" }};
+            var section = new Section { Fields = fieldsList };
+
+            // act
+            var fieldsPayload = SlackClient.SerializeObject(fieldsList);
+            var payload = SlackClient.SerializeObject(section);
+
+            // assert
+            payload.Should().Contain($"\"fields\":{fieldsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeAccessory()
+        {
+            // arrange
+            var accessoryList = new List<Element> { new Button() };
+            var section = new Section { Accessory = accessoryList };
+
+            // act
+            var accessoryPayload = SlackClient.SerializeObject(accessoryList);
+            var payload = SlackClient.SerializeObject(section);
+
+            // assert
+            payload.Should().Contain($"\"accessory\":{accessoryPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/SelectElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SelectElementFixtures.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class SelectElementFixtures
+    {
+        [Theory]
+        [InlineData(ElementType.MultiSelectStatic, "multi_static_select")]
+        [InlineData(ElementType.MultiSelectExternal, "multi_external_select")]
+        [InlineData(ElementType.MultiSelectUsers, "multi_users_select")]
+        [InlineData(ElementType.MultiSelectConversations, "multi_conversations_select")]
+        [InlineData(ElementType.MultiSelectChannels, "multi_channels_select")]
+        [InlineData(ElementType.SelectStatic, "static_select")]
+        [InlineData(ElementType.SelectExternal, "external_select")]
+        [InlineData(ElementType.SelectUsers, "users_select")]
+        [InlineData(ElementType.SelectConversations, "conversations_select")]
+        [InlineData(ElementType.SelectChannels, "channels_select")]
+        public void ShouldSerializeType(ElementType elementType, string expected)
+        {
+            // arrange
+            var select = new Select(elementType);
+
+            // act
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"type\":\"{expected}\"");
+        }
+
+        [Fact]
+        public void ShouldSerializeActionId()
+        {
+            // arrange
+            var button = new Select(ElementType.MultiSelectStatic) { ActionId = "Action123" };
+
+            // act
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain("\"action_id\":\"Action123\"");
+        }
+
+        [Fact]
+        public void ShouldSerializePlaceholder()
+        {
+            // arrange
+            var text = new TextObject();
+            var button = new Select(ElementType.MultiSelectStatic) { Placeholder = text };
+
+            // act
+            var textPayload = SlackClient.SerializeObject(text);
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain($"\"placeholder\":{textPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeConfirm()
+        {
+            // arrange
+            var confirm = new Confirmation();
+            var button = new Select(ElementType.MultiSelectStatic) { Confirm = confirm };
+
+            // act
+            var confirmPayload = SlackClient.SerializeObject(confirm);
+            var payload = SlackClient.SerializeObject(button);
+
+            // assert
+            payload.Should().Contain($"\"confirm\":{confirmPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/SelectExternalElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SelectExternalElementFixtures.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class SelectExternalElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeMinQueryLength()
+        {
+            // arrange
+            var select = new SelectExternal { MinQueryLength = 5 };
+
+            // act
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"min_query_length\":5");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOption()
+        {
+            // arrange
+            var option = new Option { Value = "Value123" };
+            var select = new SelectExternal { InitialOption = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_option\":{optionsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/SelectStaticElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SelectStaticElementFixtures.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class SelectStaticElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeOptions()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var select = new SelectStatic { Options = options };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(options);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"options\":{optionsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOption()
+        {
+            // arrange
+            var option = new Option { Value = "Value123" };
+            var select = new SelectStatic { InitialOption = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_option\":{optionsPayload}");
+        }
+
+        [Fact]
+        public void ShouldSerializeInitialOptionGroup()
+        {
+            // arrange
+            var options = new List<Option> { new Option { Value = "Value123" }};
+            var groups = new List<OptionGroup> { new OptionGroup { Options = options }};
+            var select = new SelectStatic { OptionGroups = groups };
+
+            // act
+            var groupsPayload = SlackClient.SerializeObject(groups);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"option_groups\":{groupsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/SelectUsersElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SelectUsersElementFixtures.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class SelectUsersElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialUser()
+        {
+            // arrange
+            var option = "User321";
+            var select = new SelectUsers { InitialUser = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_user\":{optionsPayload}");
+        }
+    }
+
+    public class SelectConversationsElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialConversation()
+        {
+            // arrange
+            var option = "Convo321";
+            var select = new SelectConversations { InitialConversation = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_conversation\":{optionsPayload}");
+        }
+    }
+
+    public class SelectChannelsElementFixtures
+    {
+        [Fact]
+        public void ShouldSerializeInitialChannel()
+        {
+            // arrange
+            var option = "Convo321";
+            var select = new SelectChannels { InitialChannel = option };
+
+            // act
+            var optionsPayload = SlackClient.SerializeObject(option);
+            var payload = SlackClient.SerializeObject(select);
+
+            // assert
+            payload.Should().Contain($"\"initial_channel\":{optionsPayload}");
+        }
+    }
+}

--- a/src/Slack.Webhooks.Tests/Slack.Webhooks.Tests.csproj
+++ b/src/Slack.Webhooks.Tests/Slack.Webhooks.Tests.csproj
@@ -1,29 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net45;netcoreapp2</TargetFrameworks>
     <Deterministic>False</Deterministic>
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
   </PropertyGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp2' ">
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Numerics" />
+    <Reference Include="System"/>
+    <Reference Include="System.ComponentModel.Composition"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.IO.Compression"/>
+    <Reference Include="System.Net.Http"/>
+    <Reference Include="System.Numerics"/>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="Microsoft.CSharp"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Xml"/>
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Slack.Webhooks\Slack.Webhooks.csproj">
@@ -32,20 +30,20 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config"/>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0"/>
+    <PackageReference Include="Moq" Version="4.13.1"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.9.0"/>
   </ItemGroup>
-  
 </Project>

--- a/src/Slack.Webhooks.Tests/SlackClientFixtures.cs
+++ b/src/Slack.Webhooks.Tests/SlackClientFixtures.cs
@@ -9,22 +9,22 @@ using Xunit;
 
 namespace Slack.Webhooks.Tests
 {
-    public class SlackClientShould
+    public class SlackClientFixtures
     {
         [Fact]
-        public void ThrowExceptionWhenUrlIsEmpty()
+        public void ShouldThrowExceptionWhenUrlIsEmpty()
         {
             Assert.Throws<ArgumentException>(() => new SlackClient(string.Empty));
         }
 
         [Fact]
-        public void ThrowExceptionIfUrlIsMalformed()
+        public void ShouldThrowExceptionIfUrlIsMalformed()
         {
             Assert.Throws<ArgumentException>(() => new SlackClient("[/]dodgy_url!@.slack.com"));
         }
 
         [Fact]
-        public void ReturnTrueIfPostSucceeds()
+        public void ShouldReturnTrueIfPostSucceeds()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/mygreathook";
@@ -40,7 +40,7 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
-        public void ReturnFalseIfPostFails()
+        public void ShouldReturnFalseIfPostFails()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/invalidhook";
@@ -56,7 +56,7 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
-        public void RememberTimeout()
+        public void ShouldRememberTimeout()
         {
             const string hookUrl = "https://hooks.slack.com/invalid";
             var timeoutSeconds = 2;
@@ -66,7 +66,7 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
-        public void ReuseHttpClient()
+        public void ShouldReuseHttpClient()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/invalid";
@@ -93,7 +93,7 @@ namespace Slack.Webhooks.Tests
 
 
         [Fact]
-        public void ContainSerializedMessage()
+        public void ShouldContainSerializedMessage()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/invalid";
@@ -101,7 +101,7 @@ namespace Slack.Webhooks.Tests
             var httpMessageHandler = GetMockHttpMessageHandler(callback: (req, token) =>
             {
                 var json = req.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                postedMessage = SlackMessage.FromJson(json);
+                postedMessage = SlackClient.DeserializeObject(json);
             });
 
             var httpClient = new HttpClient(httpMessageHandler.Object, false);
@@ -120,7 +120,7 @@ namespace Slack.Webhooks.Tests
         }
 
         [Fact]
-        public void PostToMultipleChannels()
+        public void ShouldPostToMultipleChannels()
         {
             //arrange
             const string hookUrl = "https://hooks.slack.com/invalid";
@@ -128,7 +128,7 @@ namespace Slack.Webhooks.Tests
             var httpMessageHandler = GetMockHttpMessageHandler(callback: (req, token) =>
             {
                 var json = req.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                var postedMessage = SlackMessage.FromJson(json);
+                var postedMessage = SlackClient.DeserializeObject(json);
                 channelsPostedTo.Add(postedMessage.Channel);
             });
 

--- a/src/Slack.Webhooks.Tests/TextElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/TextElementFixtures.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Slack.Webhooks.Elements;
+using Xunit;
+
+namespace Slack.Webhooks.Tests
+{
+    public class TextElementFixtures
+    {
+        [Theory]
+        [InlineData(TextObject.TextType.Markdown, "mrkdwn")]
+        [InlineData(TextObject.TextType.PlainText, "plain_text")]
+        public void ShouldContainTextType(TextObject.TextType textType, string expected)
+        {
+            // arrange
+            var text = new TextObject { Type = textType };
+
+            // act
+            var payload = SlackClient.SerializeObject(text);
+
+            // assert
+            payload.Should().Contain($"\"type\":\"{expected}\"");
+
+        }
+
+        [Fact]
+        public void ShouldNotContainEmojiWhenTextTypeIsMarkdown()
+        {
+            // arrange
+            var text = new TextObject { Type = TextObject.TextType.Markdown };
+
+            // act
+            var payload = SlackClient.SerializeObject(text);
+
+            // assert
+            payload.Should().NotContain("\"emoji\":");
+        }
+
+        [Fact]
+        public void ShouldNotSerializeVerbatimWhenTextTypeIsPlainText()
+        {
+            // arrange
+            var text = new TextObject { Type = TextObject.TextType.PlainText };
+
+            // act
+            var payload = SlackClient.SerializeObject(text);
+
+            // assert
+            payload.Should().NotContain("\"verbatim\":");
+        }
+    }
+}

--- a/src/Slack.Webhooks/Block.cs
+++ b/src/Slack.Webhooks/Block.cs
@@ -1,0 +1,35 @@
+﻿namespace Slack.Webhooks
+{
+    /// <summary>
+    /// Blocks are a series of components that can be combined to create visually rich and compellingly interactive messages.
+    /// 
+    /// Read our guide to composing rich message layouts to learn where and how to use each of these components. You can include up to 50 blocks in each message.
+    /// https://api.slack.com/messaging/composing/layouts
+    /// </summary>    
+    /// <seealso cref="Actions" />
+    /// <seealso cref="Context" />
+    /// <seealso cref="Divider" />
+    /// <seealso cref="File" />
+    /// <seealso cref="Image" />
+    /// <seealso cref="Input" />
+    /// <seealso cref="Section" />
+    public class Block
+    {
+        protected readonly BlockType _blockType;
+        /// <summary>
+        /// The <see cref="BlockType"/> of this instance of <see cref="Block"/>.
+        /// </summary>
+        public BlockType Type { get { return _blockType; } }
+        /// <summary>
+        /// A string acting as a unique identifier for a block. 
+        /// You can use this block_id when you receive an interaction payload to identify the source of the action. 
+        /// If not specified, one will be generated. Maximum length for this field is 255 characters.
+        /// </summary>
+        public string BlockId { get; set; }
+
+        protected Block(BlockType blockType)
+        {
+            _blockType = blockType;
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Actions.cs
+++ b/src/Slack.Webhooks/Blocks/Actions.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// A block that is used to hold interactive <see cref="Interfaces.IActionElement"/>s.
+    /// </summary>
+    public class Actions : Block
+    {
+        /// <summary>
+        /// An array of interactive element objects - <see cref="Elements.Button"/>, <see cref="Elements.Select"/> menus, <see cref="Elements.Overflow"/> menus, or <see cref="Elements.DatePicker"/>. 
+        /// There is a maximum of 5 elements in each action block.
+        /// </summary>
+        /// <seealso cref="Interfaces.IActionElement"/>
+        /// <seealso cref="Elements.Button"/>
+        /// <seealso cref="Elements.SelectUsers"/>
+        /// <seealso cref="Elements.SelectChannels"/>
+        /// <seealso cref="Elements.SelectConversations"/>
+        /// <seealso cref="Elements.SelectStatic"/>
+        /// <seealso cref="Elements.SelectExternal"/>
+        /// <seealso cref="Elements.Overflow"/>
+        /// <seealso cref="Elements.DatePicker"/>
+        public IList<IActionElement> Elements { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Actions"/> instance.
+        /// </summary>
+        public Actions() : base(BlockType.Actions)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Context.cs
+++ b/src/Slack.Webhooks/Blocks/Context.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// Displays message context, which can include both images and text.
+    /// </summary>
+    public class Context : Block
+    {
+        /// <summary>
+        /// 	An array of <see cref="Elements.Image"/> elements and <see cref="Elements.TextObject"/>s. Maximum number of items is 10.
+        /// </summary>
+        public List<IContextElement> Elements { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Context"/> instance.
+        /// </summary>
+        public Context() : base(BlockType.Context)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Divider.cs
+++ b/src/Slack.Webhooks/Blocks/Divider.cs
@@ -1,0 +1,15 @@
+﻿namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// A content divider, like an &lt;hr&gt;, to split up different blocks inside of a message. The divider block is nice and neat, requiring only a <see cref="Block.Type"/>.
+    /// </summary>
+    public class Divider : Block
+    {
+        /// <summary>
+        /// Create a new <see cref="Divider"/> instance.
+        /// </summary>
+        public Divider() : base(BlockType.Divider)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/File.cs
+++ b/src/Slack.Webhooks/Blocks/File.cs
@@ -1,0 +1,24 @@
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// Displays a remote file.
+    /// </summary>
+    public class File : Block
+    {
+        /// <summary>
+        /// The external unique ID for this file.
+        /// </summary>
+        public string ExternalId { get; set; }
+        /// <summary>
+        /// At the moment, <see cref="Source"/> will always be "remote" for a remote file.
+        /// </summary>
+        public string Source { get; set; } = "remote";
+
+        /// <summary>
+        /// Create a new <see cref="File"/> instance.
+        /// </summary>
+        public File() : base(BlockType.File)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Image.cs
+++ b/src/Slack.Webhooks/Blocks/Image.cs
@@ -1,0 +1,33 @@
+﻿using Slack.Webhooks.Elements;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// A simple image block, designed to make those cat photos really pop.
+    /// </summary>
+    public class Image : Block, IContextElement
+    {
+        /// <summary>
+        /// The URL of the image to be displayed. Maximum length for this field is 3000 characters.
+        /// </summary>
+        public string ImageUrl { get; set; }
+        /// <summary>
+        /// A plain-text summary of the image. This should not contain any markup. Maximum length for this field is 2000 characters.
+        /// </summary>
+        public string AltText { get; set; }
+        /// <summary>
+        /// An optional title for the image in the form of a <see cref="TextObject"/> that can only be of <see cref="TextObject.TextType.PlainText"/>. 
+        /// Maximum length for the text in this field is 2000 characters.
+        /// </summary>
+        public TextObject Title { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Image" instance.
+        /// </summary>
+        public Image() : base(BlockType.Image)
+        {
+
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Input.cs
+++ b/src/Slack.Webhooks/Blocks/Input.cs
@@ -1,0 +1,55 @@
+using Slack.Webhooks.Elements;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// A block that collects information from users - it can hold a <see cref="Elements.PlainTextInput"/> element, 
+    /// a <see cref="Elements.Select"/> menu element, a multi-select menu element, or a <see cref="Elements.DatePicker"/>.
+    /// 
+    /// Read our guide to using modals to learn how input blocks pass information to your app.
+    /// https://api.slack.com/surfaces/modals/using#gathering_input
+    /// </summary>
+    /// <seealso cref="Interfaces.IInputElement"/>
+    /// <seealso cref="Elements.PlainTextInput"/>
+    /// <seealso cref="Elements.SelectUsers"/>
+    /// <seealso cref="Elements.SelectChannels"/>
+    /// <seealso cref="Elements.SelectConversations"/>
+    /// <seealso cref="Elements.SelectStatic"/>
+    /// <seealso cref="Elements.SelectExternal"/>
+    /// <seealso cref="Elements.MultiSelectUsers"/>
+    /// <seealso cref="Elements.MultiSelectChannels"/>
+    /// <seealso cref="Elements.MultiSelectConversations"/>
+    /// <seealso cref="Elements.MultiSelectStatic"/>
+    /// <seealso cref="Elements.MultiSelectExternal"/>
+    /// <seealso cref="Elements.DatePicker"/>
+    public class Input : Block
+    {
+        /// <summary>
+        /// A label that appears above an <see cref="Input"/> element in the form of a <see cref="TextObject"/> that can only be of <see cref="TextObject.TextType.PlainText"/>. 
+        /// Maximum length for the text in this field is 2000 characters.
+        /// </summary>
+        public TextObject Label { get; set; }
+        /// <summary>
+        /// An optional hint that appears below an input element in a lighter grey. It must be a <see cref="TextObject"/> that can only be of <see cref="TextObject.TextType.PlainText"/>. 
+        /// Maximum length for the text in this field is 2000 characters.
+        /// </summary>
+        public TextObject Hint { get; set; }
+        /// <summary>
+        /// A boolean that indicates whether the input element may be empty when a user submits the modal. Defaults to false.
+        /// </summary>
+        public bool Optional { get; set; }
+        /// <summary>
+        /// An <see cref="Elements.PlainTextInput"/> element, a <see cref="Elements.Select"/> menu element, a multi-select menu element, or a <see cref="Elements.DatePicker"/>.
+        /// </summary>
+        public IInputElement Element { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Input"/> instance.
+        /// </summary>
+        public Input() : base(BlockType.Input)
+        {
+            
+        }
+    }
+}

--- a/src/Slack.Webhooks/Blocks/Section.cs
+++ b/src/Slack.Webhooks/Blocks/Section.cs
@@ -22,7 +22,7 @@ namespace Slack.Webhooks.Blocks
         /// <summary>
         /// One of the available <see cref="Element"/> objects.
         /// </summary>
-        public IList<Element> Accessory { get; set; }
+        public Element Accessory { get; set; }
 
         /// <summary>
         /// Create a new <see cref="Section"/> instance.

--- a/src/Slack.Webhooks/Blocks/Section.cs
+++ b/src/Slack.Webhooks/Blocks/Section.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using Slack.Webhooks.Elements;
+
+namespace Slack.Webhooks.Blocks
+{
+    /// <summary>
+    /// A <see cref="Section"/> is one of the most flexible blocks available - it can be used as a simple text block, 
+    /// in combination with text fields, or side-by-side with any of the available block elements.
+    /// </summary>
+    public class Section : Block
+    {
+        /// <summary>
+        /// The <see cref="Text"/> for the block, in the form of a <see cref="TextObject"/>. Maximum length for the text in this field is 3000 characters.
+        /// </summary>
+        public TextObject Text { get; set; }
+        /// <summary>
+        /// An array of <see cref="TextObject"/>s. Any text objects included with <see cref="Fields"/> will be rendered in a compact 
+        /// format that allows for 2 columns of side-by-side text. Maximum number of items is 10. 
+        /// Maximum length for the text in each item is 2000 characters.
+        /// </summary>
+        public IList<TextObject> Fields { get; set; }
+        /// <summary>
+        /// One of the available <see cref="Element"/> objects.
+        /// </summary>
+        public IList<Element> Accessory { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Section"/> instance.
+        /// </summary>
+        public Section() : base(BlockType.Section)
+        {
+            
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Button.cs
+++ b/src/Slack.Webhooks/Elements/Button.cs
@@ -1,0 +1,63 @@
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Actions"/> blocks.
+    /// 
+    /// An interactive component that inserts a button. The button can be a trigger for anything from opening a simple link to starting a complex workflow.
+    /// 
+    /// To use interactive components, you will need to make some changes to prepare your app. Read our guide to enabling interactivity.
+    /// </summary>
+    public class Button : Element, IActionElement
+    {
+        /// <summary>
+        /// A <see cref="TextObject"/> that defines the button's text. Can only be of type: <see cref="TextObject.TextType.PlainText"/>. Maximum length for the text in this field is 75 characters.
+        /// </summary>
+        public TextObject Text { get; set; }
+        /// <summary>
+        /// An identifier for this action. You can use this when you receive an interaction payload 
+        /// to identify the source of the action. Should be unique among all other action_ids used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        ///
+        /// https://api.slack.com/interactivity/handling#payloads
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// A URL to load in the user's browser when the button is clicked. 
+        /// Maximum length for this field is 3000 characters. 
+        /// If you're using url, you'll still receive an interaction payload and will need to send an acknowledgement response.
+        ///
+        /// https://api.slack.com/interactivity/handling#payloads
+        /// https://api.slack.com/interactivity/handling#acknowledgment_response
+        /// </summary>
+        public string Url { get; set; }
+        /// <summary>
+        /// The value to send along with the interaction payload. Maximum length for this field is 2000 characters.
+        ///
+        /// https://api.slack.com/interactivity/handling#payloads
+        /// </summary>
+        public string Value { get; set; }
+        /// <summary>
+        /// Decorates buttons with alternative visual color schemes. Use this option with restraint.
+        /// 
+        /// "primary" gives buttons a green outline and text, ideal for affirmation or confirmation actions. "primary" should only be used for one button within a set.
+        /// 
+        /// "danger" gives buttons a red outline and text, and should be used when the action is destructive. Use "danger" even more sparingly than "primary".
+        /// 
+        /// If you don't include this field, the default button style will be used.
+        /// </summary>
+        public string Style { get; set; }
+        /// <summary>
+        /// A <see cref="Confirmation"/> object that defines an optional confirmation dialog after the button is clicked.
+        /// </summary>
+        public Confirmation Confirm { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Button"/> instance.
+        /// </summary>
+        public Button() : base(ElementType.Button)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Confirmation.cs
+++ b/src/Slack.Webhooks/Elements/Confirmation.cs
@@ -1,0 +1,25 @@
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// An object that defines a dialog that provides a confirmation step to any interactive element. This dialog will ask the user to confirm their action by offering a confirm and deny buttons.
+    /// </summary>
+    public class Confirmation
+    {
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/>-only <see cref="TextObject"/> that defines the dialog's title. Maximum length for this field is 100 characters.
+        /// </summary>
+        public TextObject Title { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject"/> that defines the explanatory text that appears in the confirm dialog. Maximum length for the <see cref="TextObject.Text"/> in this field is 300 characters.
+        /// </summary>
+        public TextObject Text { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/>-only <see cref="TextObject"/> to define the text of the button that confirms the action. Maximum length for the <see cref="TextObject.Text"/> in this field is 30 characters.
+        /// </summary>
+        public TextObject Confirm { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/>-only <see cref="TextObject"/> to define the text of the button that cancels the action. Maximum length for the <see cref="TextObject.Text"/> in this field is 30 characters.
+        /// </summary>
+        public TextObject Deny { get; set; }
+    }
+}

--- a/src/Slack.Webhooks/Elements/DatePicker.cs
+++ b/src/Slack.Webhooks/Elements/DatePicker.cs
@@ -1,0 +1,44 @@
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// An element which lets users easily select a date from a calendar style UI.
+    /// 
+    /// To use interactive components like this, you will need to make some changes to prepare your app. Read our guide to enabling interactivity.
+    /// https://api.slack.com/interactivity/handling
+    /// </summary>
+    public class DatePicker : Element, IActionElement, IInputElement
+    {
+        /// <summary>
+        /// An identifier for the action triggered when a menu option is selected. 
+        /// You can use this when you receive an interaction payload to identify the source of the action. 
+        /// Should be unique among all other <see cref="ActionId"/>s used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/> only <see cref="TextObject"/> that defines the placeholder text shown on the datepicker. 
+        /// Maximum length for the text in this field is 150 characters.
+        /// </summary>
+        public TextObject Placeholder { get; set; }
+        /// <summary>
+        /// The initial date that is selected when the element is loaded. This should be in the format YYYY-MM-DD.
+        /// </summary>
+        public string InitialDate { get; set; }
+        /// <summary>
+        /// A <see cref="Confirmation"/> object that defines an optional confirmation dialog that appears after a date is selected.
+        /// </summary>
+        public Confirmation Confirm { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="DatePicker"/> instance.
+        /// </summary>
+        public DatePicker() : base(ElementType.DatePicker)
+        {
+            
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Element.cs
+++ b/src/Slack.Webhooks/Elements/Element.cs
@@ -1,0 +1,20 @@
+namespace Slack.Webhooks.Elements
+{
+    public class Element
+    {
+        /// <summary>
+        /// The type of element represented by <see cref="ElementType"/>.
+        /// </summary>
+        public ElementType Type { get; set; }
+
+        protected Element(ElementType elementType)
+        {
+            Type = elementType;
+        }
+
+        public bool ShouldSerializeType()
+        {
+            return Type != ElementType.Unknown;
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Image.cs
+++ b/src/Slack.Webhooks/Elements/Image.cs
@@ -1,0 +1,28 @@
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Context"/> blocks.
+    /// 
+    /// An element to insert an image as part of a larger block of content. If you want a block with only an image in it, you're looking for the <see cref="Blocks.Image"/> block.
+    /// </summary>
+    public class Image : Element
+    {
+        /// <summary>
+        /// The URL of the image to be displayed.
+        /// </summary>
+        public string ImageUrl { get; set; }
+        /// <summary>
+        /// A plain-text summary of the image. This should not contain any markup.
+        /// </summary>
+        public string AltText { get; set; }
+
+        /// <summary>
+        /// Create a new <see cref="Image"/> instance.
+        /// </summary>
+        public Image() : base(ElementType.Image)
+        {
+            
+        }
+
+    }
+}

--- a/src/Slack.Webhooks/Elements/Image.cs
+++ b/src/Slack.Webhooks/Elements/Image.cs
@@ -1,3 +1,5 @@
+using Slack.Webhooks.Interfaces;
+
 namespace Slack.Webhooks.Elements
 {
     /// <summary>
@@ -5,7 +7,7 @@ namespace Slack.Webhooks.Elements
     /// 
     /// An element to insert an image as part of a larger block of content. If you want a block with only an image in it, you're looking for the <see cref="Blocks.Image"/> block.
     /// </summary>
-    public class Image : Element
+    public class Image : Element, IContextElement
     {
         /// <summary>
         /// The URL of the image to be displayed.

--- a/src/Slack.Webhooks/Elements/MultiSelect.cs
+++ b/src/Slack.Webhooks/Elements/MultiSelect.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This is the simplest form of select menu, with a static list of options passed in when defining the element.
+    /// </summary>
+    public class MultiSelectStatic : Select, IInputElement
+    {
+        /// <summary>
+        ///	An array of <see cref="Option"/> objects. 
+        /// Maximum number of options is 100. 
+        /// If <see cref="OptionGroups"/> is specified, this field should not be.
+        /// </summary>
+        public List<Option> Options { get; set; }
+        /// <summary>
+        ///	An array of <see cref="OptionGroups"/> objects. 
+        /// Maximum number of options is 100. 
+        /// If <see cref="Option"/> is specified, this field should not be.
+        /// </summary>
+        public List<OptionGroup> OptionGroups { get; set; }
+        /// <summary>
+        ///	An array of <see cref="Option"/> objects that exactly match one or 
+        /// more of the options within <see cref="Options"/> or <see cref="OptionGroups"/>. 
+        /// These options will be selected when the menu initially loads.
+        /// </summary>
+        public List<Option> InitialOptions { get; set; }
+
+        public MultiSelectStatic() : base(ElementType.MultiSelectStatic)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This menu will load its options from an external data source, allowing for a dynamic list of options.
+    /// 
+    /// Setup
+    /// To use this menu type, you'll need to configure your app first:
+    /// 
+    /// Goto your app's settings page and choose the Interactive Components feature menu.
+    /// Add a URL to the Options Load URL under Select Menus.
+    /// Save changes.
+    /// Each time a menu of this type is opened or the user starts typing in the typeahead field, we'll send a request to your specified URL. Your app should return an HTTP 200 OK response, along with an application/json post body with an object containing either an options array, or an option_groups array.
+    /// </summary>
+    public class MultiSelectExternal : Select, IInputElement
+    {
+        /// <summary>
+        /// When the typeahead field is used, a request will be sent on every 
+        /// character change. If you prefer fewer requests or more fully ideated queries, 
+        /// use the <see cref="MinQueryLength"/> attribute to tell Slack the fewest 
+        /// number of typed characters required before dispatch.
+        /// </summary>
+        public int MinQueryLength { get; set; }
+        /// <summary>
+        ///	An array of <see cref="Option"/> objects that exactly match one or 
+        /// more of the options within <see cref="Options"/> or <see cref="OptionGroups"/>. 
+        /// These options will be selected when the menu initially loads.
+        /// </summary>
+        public IList<Option> InitialOptions { get; set; }
+
+        public MultiSelectExternal() : base(ElementType.MultiSelectExternal)
+        {
+        }
+    }
+    
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This multi-select menu will populate its options with a list of Slack users visible to the current user in the active workspace.
+    /// </summary>
+    public class MultiSelectUsers : Select, IInputElement
+    {
+        /// <summary>
+        /// An array of user IDs of any valid users to be pre-selected when the menu loads.
+        /// </summary>
+        public IList<string> InitialUsers { get; set; }
+        
+        public MultiSelectUsers() : base(ElementType.MultiSelectUsers)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This multi-select menu will populate its options with a list of public and private channels, DMs, and MPIMs visible to the current user in the active workspace.
+    /// </summary>
+    public class MultiSelectConversations : Select, IInputElement
+    {
+        /// <summary>
+        /// An array of one or more IDs of any valid conversations to be pre-selected when the menu loads.
+        /// </summary>
+        public IList<string> InitialConversations { get; set; }
+        
+        public MultiSelectConversations() : base(ElementType.MultiSelectUsers)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This multi-select menu will populate its options with a list of public channels visible to the current user in the active workspace.
+    /// </summary>
+    public class MultiSelectChannels : Select, IInputElement
+    {
+        /// <summary>
+        /// An array of one or more IDs of any valid public channel to be pre-selected when the menu loads.
+        /// </summary>
+        public IList<string> InitialChannels { get; set; }
+        
+        public MultiSelectChannels() : base(ElementType.MultiSelectUsers)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/MultiSelect.cs
+++ b/src/Slack.Webhooks/Elements/MultiSelect.cs
@@ -97,7 +97,7 @@ namespace Slack.Webhooks.Elements
         /// </summary>
         public IList<string> InitialConversations { get; set; }
         
-        public MultiSelectConversations() : base(ElementType.MultiSelectUsers)
+        public MultiSelectConversations() : base(ElementType.MultiSelectConversations)
         {
         }
     }
@@ -114,7 +114,7 @@ namespace Slack.Webhooks.Elements
         /// </summary>
         public IList<string> InitialChannels { get; set; }
         
-        public MultiSelectChannels() : base(ElementType.MultiSelectUsers)
+        public MultiSelectChannels() : base(ElementType.MultiSelectChannels)
         {
         }
     }

--- a/src/Slack.Webhooks/Elements/Option.cs
+++ b/src/Slack.Webhooks/Elements/Option.cs
@@ -1,0 +1,37 @@
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// An object that represents a single selectable item in a <see cref="Elements.Select"/> menu, multi-select menu, <see cref="Elements.RadioButtons"/> group, or <see cref="Elements.Overflow"/> menu.
+    /// </summary>
+    /// <seealso cref="Elements.SelectUsers"/>
+    /// <seealso cref="Elements.SelectChannels"/>
+    /// <seealso cref="Elements.SelectConversations"/>
+    /// <seealso cref="Elements.SelectStatic"/>
+    /// <seealso cref="Elements.SelectExternal"/>
+    /// <seealso cref="Elements.MultiSelectUsers"/>
+    /// <seealso cref="Elements.MultiSelectChannels"/>
+    /// <seealso cref="Elements.MultiSelectConversations"/>
+    /// <seealso cref="Elements.MultiSelectStatic"/>
+    /// <seealso cref="Elements.MultiSelectExternal"/>
+    /// <seealso cref="Elements.Overflow"/>
+    /// <seealso cref="Elements.RadioButtons"/>
+    public class Option
+    {
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/> only <see cref="TextObject"/> that defines the text shown in the option on the menu. Maximum length for the text in this field is 75 characters.
+        /// </summary>
+        public TextObject Text { get; set; }
+        /// <summary>
+        /// The string value that will be passed to your app when this option is chosen. Maximum length for this field is 75 characters.
+        /// </summary>
+        public string Value { get; set; }
+        /// <summary>
+        /// A URL to load in the user's browser when the option is clicked. The url attribute is only available in <see cref="Elements.Overflow"/> menus. 
+        /// Maximum length for this field is 3000 characters. If you're using url, you'll still receive an interaction payload and will need to send an acknowledgement response.
+        ///
+        /// https://api.slack.com/interactivity/handling#payloads
+        /// https://api.slack.com/interactivity/handling#acknowledgment_response
+        /// </summary>
+        public string Url { get; set; }
+    }
+}

--- a/src/Slack.Webhooks/Elements/OptionGroup.cs
+++ b/src/Slack.Webhooks/Elements/OptionGroup.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Provides a way to group options in a <see cref="Elements.Select"/>  menu or multi-select menu.
+    /// </summary>
+    /// <seealso cref="Elements.SelectUsers"/>
+    /// <seealso cref="Elements.SelectChannels"/>
+    /// <seealso cref="Elements.SelectConversations"/>
+    /// <seealso cref="Elements.SelectStatic"/>
+    /// <seealso cref="Elements.SelectExternal"/>
+    /// <seealso cref="Elements.MultiSelectUsers"/>
+    /// <seealso cref="Elements.MultiSelectChannels"/>
+    /// <seealso cref="Elements.MultiSelectConversations"/>
+    /// <seealso cref="Elements.MultiSelectStatic"/>
+    /// <seealso cref="Elements.MultiSelectExternal"/>
+    public class OptionGroup
+    {
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/> only <see cref="TextObject"/> that defines the label shown above this group of options. Maximum length for the <see cref="TextObject.Text"/> in this field is 75 characters.
+        /// </summary>
+        public TextObject Label { get; set; }
+        /// <summary>
+        /// An array of <see cref="Option"/> objects that belong to this specific group. Maximum of 100 items.
+        /// </summary>
+        public IList<Option> Options { get; set; }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Overflow.cs
+++ b/src/Slack.Webhooks/Elements/Overflow.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/> and <see cref="Blocks.Actions"/> blocks.
+    /// 
+    /// This is like a cross between a button and a select menu - when a user clicks on this overflow button, they will be presented with a list of options to choose from. Unlike the select menu, there is no typeahead field, and the button always appears with an ellipsis ("…") rather than customisable text.
+    /// 
+    /// As such, it is usually used if you want a more compact layout than a select menu, or to supply a list of less visually important actions after a row of buttons. You can also specify simple URL links as overflow menu options, instead of actions.
+    /// 
+    /// To use interactive components like this, you will need to make some changes to prepare your app. Read our guide to enabling interactivity.
+    /// https://api.slack.com/interactivity/handling
+    /// </summary>
+    public class Overflow : Element, IActionElement
+    {
+        /// <summary>
+        /// An identifier for the action triggered when a menu option is selected. 
+        /// You can use this when you receive an interaction payload to identify the source of the action. 
+        /// Should be unique among all other <see cref="ActionId"/>s used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// An array of <see cref="Option"/> objects to display in the menu. Maximum number of options is 5, minimum is 2.
+        /// </summary>
+        public IList<Option> Options { get; set; }
+        /// <summary>
+        /// A <see cref="Confirmation"/> object that defines an optional confirmation dialog that appears after a menu item is selected.
+        /// </summary>
+        public Confirmation Confirm { get; set; }
+        public Overflow() : base(ElementType.Overflow)
+        {
+            
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/PlainTextInput.cs
+++ b/src/Slack.Webhooks/Elements/PlainTextInput.cs
@@ -1,0 +1,48 @@
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// A plain-text input, similar to the HTML &lt;input&gt; tag, creates a field where a user can enter freeform data. It can appear as a single-line field or a larger textarea using the <see cref="MultiLine"/>> flag.
+    /// 
+    /// Plain-text input elements are currently only available in modals. To use them, you will need to make some changes to prepare your app. Read about preparing your app for modals.
+    /// https://api.slack.com/surfaces/modals/using#preparing_for_modals
+    /// </summary>
+    public class PlainTextInput : Element, IInputElement
+    {
+        /// <summary>
+        /// An identifier for the action triggered when a menu option is selected. 
+        /// You can use this when you receive an interaction payload to identify the source of the action. 
+        /// Should be unique among all other <see cref="ActionId"/>s used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/> only <see cref="TextObject"/> that defines the placeholder text shown in the plain-text input. 
+        /// Maximum length for the <see cref="TextObject.Text"/> in this field is 150 characters.
+        /// </summary>
+        public TextObject Placeholder { get; set; }
+        /// <summary>
+        /// The initial value in the plain-text input when it is loaded.
+        /// </summary>
+        public string InitialValue { get; set; }
+        /// <summary>
+        /// Indicates whether the input will be a single line (false) or a larger textarea (true). Defaults to false.
+        /// </summary>
+        public bool MultiLine { get; set; }
+        /// <summary>
+        /// The minimum length of input that the user must provide. If the user provides less, they will receive an error. Maximum value is 3000.
+        /// </summary>
+        public int MinLength { get; set; }
+        /// <summary>
+        /// The maximum length of input that the user can provide. If the user provides more, they will receive an error.
+        /// </summary>
+        public int MaxLength { get; set; }
+        
+        public PlainTextInput() : base(ElementType.PlainTextInput)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/RadioButton.cs
+++ b/src/Slack.Webhooks/Elements/RadioButton.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// A radio button group that allows a user to choose one item from a list of possible options.
+    /// 
+    /// Radio buttons are only supported in the following app surfaces: Home tabs
+    /// https://api.slack.com/surfaces/tabs
+    /// 
+    /// To use interactive components like this, you will need to make some changes to prepare your app. Read our guide to enabling interactivity.
+    /// https://api.slack.com/interactivity/handling
+    /// </summary>
+    public class RadioButtons : Element
+    {
+        /// <summary>
+        /// An identifier for the action triggered when a menu option is selected. 
+        /// You can use this when you receive an interaction payload to identify the source of the action. 
+        /// Should be unique among all other <see cref="ActionId"/>s used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// An array of <see cref="Option"/> objects.
+        /// </summary>
+        public IList<Option> Options { get; set; }
+        /// <summary>
+        /// An <see cref="Option"/> object that exactly matches one of the options within <see cref="Options"/>. This option will be selected when the radio button group initially loads.
+        /// </summary>
+        public Option InitialOption { get; set; }
+        /// <summary>
+        /// A <see cref="Confirmation"/> object that defines an optional confirmation dialog that appears after clicking one of the radio buttons in this element.
+        /// </summary>
+        public Confirmation Confirm { get; set; }
+
+        public RadioButtons() : base(ElementType.RadioButtons)
+        {
+            
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Select.cs
+++ b/src/Slack.Webhooks/Elements/Select.cs
@@ -1,0 +1,144 @@
+using System.Collections.Generic;
+using Slack.Webhooks.Interfaces;
+
+namespace Slack.Webhooks.Elements
+{
+    public class Select : Element
+    {
+        /// <summary>
+        /// An identifier for the action triggered when a menu option is selected. 
+        /// You can use this when you receive an interaction payload to identify the source of the action. 
+        /// Should be unique among all other <see cref="ActionId"/>s used elsewhere by your app. 
+        /// Maximum length for this field is 255 characters.
+        /// </summary>
+        public string ActionId { get; set; }
+        /// <summary>
+        /// A <see cref="TextObject.TextType.PlainText"/> only <see cref="TextObject"/> that defines the placeholder text shown on the menu. 
+        /// Maximum length for the text in this field is 150 characters.
+        /// </summary>
+        public TextObject Placeholder { get; set; }
+        /// <summary>
+        /// A <see cref="Confirmation"/> object that defines an optional confirmation dialog that appears before the choice(s) are submitted
+        /// </summary>
+        public Confirmation Confirm { get; set; }
+        public Select(ElementType elementType) : base(elementType)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This is the simplest form of select menu, with a static list of options passed in when defining the element.
+    /// </summary>
+    public class SelectStatic : Select, IActionElement, IInputElement
+    {
+        /// <summary>
+        ///	An array of <see cref="Option"/> objects. 
+        /// Maximum number of options is 100. 
+        /// If <see cref="OptionGroups"/> is specified, this field should not be.
+        /// </summary>
+        public List<Option> Options { get; set; }
+        /// <summary>
+        ///	An array of <see cref="OptionGroups"/> objects. 
+        /// Maximum number of options is 100. 
+        /// If <see cref="Option"/> is specified, this field should not be.
+        /// </summary>
+        public List<OptionGroup> OptionGroups { get; set; }
+        /// <summary>
+        ///	A single <see cref="Option"/> that exactly match one 
+        /// of the options within <see cref="Options"/> or <see cref="OptionGroups"/>. 
+        /// This option will be selected when the menu initially loads.
+        /// </summary>
+        public Option InitialOption { get; set; }
+
+        public SelectStatic() : base(ElementType.SelectStatic)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This menu will load its options from an external data source, allowing for a dynamic list of options.
+    /// 
+    /// Setup
+    /// To use this menu type, you'll need to configure your app first:
+    /// 
+    /// Goto your app's settings page and choose the Interactive Components feature menu.
+    /// Add a URL to the Options Load URL under Select Menus.
+    /// Save changes.
+    /// Each time a menu of this type is opened or the user starts typing in the typeahead field, we'll send a request to your specified URL. Your app should return an HTTP 200 OK response, along with an application/json post body with an object containing either an options array, or an option_groups array.
+    /// </summary>
+    public class SelectExternal : Select, IActionElement, IInputElement
+    {
+        /// <summary>
+        /// When the typeahead field is used, a request will be sent on every 
+        /// character change. If you prefer fewer requests or more fully ideated queries, 
+        /// use the <see cref="MinQueryLength"/> attribute to tell Slack the fewest 
+        /// number of typed characters required before dispatch.
+        /// </summary>
+        public int MinQueryLength { get; set; }
+        /// <summary>
+        ///	A single <see cref="Option"/> that exactly match one 
+        /// of the options within <see cref="Options"/> or <see cref="OptionGroups"/>. 
+        /// This option will be selected when the menu initially loads.
+        /// </summary>
+        public Option InitialOption { get; set; }
+
+        public SelectExternal() : base(ElementType.SelectExternal)
+        {
+        }
+    }
+    
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This select menu will populate its options with a list of Slack users visible to the current user in the active workspace.
+    /// </summary>
+    public class SelectUsers : Select, IActionElement, IInputElement
+    {
+        /// <summary>
+        /// The user ID of any valid user to be pre-selected when the menu loads.
+        /// </summary>
+        public string InitialUser { get; set; }
+        
+        public SelectUsers() : base(ElementType.SelectUsers)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This select menu will populate its options with a list of public and private channels, DMs, and MPIMs visible to the current user in the active workspace.
+    /// </summary>
+    public class SelectConversations : Select, IActionElement, IInputElement
+    {
+        /// <summary>
+        /// The ID of any valid conversation to be pre-selected when the menu loads.
+        /// </summary>
+        public string InitialConversation { get; set; }
+        
+        public SelectConversations() : base(ElementType.SelectUsers)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Works with <see cref="Blocks.Section"/>, <see cref="Blocks.Actions"/> and <see cref="Blocks.Input"/> blocks.
+    /// 
+    /// This select menu will populate its options with a list of public channels visible to the current user in the active workspace.
+    /// </summary>
+    public class SelectChannels : Select, IActionElement, IInputElement
+    {
+        /// <summary>
+        /// The ID of any valid public channel to be pre-selected when the menu loads.
+        /// </summary>
+        public string InitialChannel { get; set; }
+        
+        public SelectChannels() : base(ElementType.SelectUsers)
+        {
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/Select.cs
+++ b/src/Slack.Webhooks/Elements/Select.cs
@@ -120,7 +120,7 @@ namespace Slack.Webhooks.Elements
         /// </summary>
         public string InitialConversation { get; set; }
         
-        public SelectConversations() : base(ElementType.SelectUsers)
+        public SelectConversations() : base(ElementType.SelectConversations)
         {
         }
     }
@@ -137,7 +137,7 @@ namespace Slack.Webhooks.Elements
         /// </summary>
         public string InitialChannel { get; set; }
         
-        public SelectChannels() : base(ElementType.SelectUsers)
+        public SelectChannels() : base(ElementType.SelectChannels)
         {
         }
     }

--- a/src/Slack.Webhooks/Elements/TextObject.cs
+++ b/src/Slack.Webhooks/Elements/TextObject.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Slack.Webhooks.Interfaces;
+using System.Runtime.Serialization;
+
+namespace Slack.Webhooks.Elements
+{
+    /// <summary>
+    /// An object containing some text, formatted either as <see cref="TextType.PlainText"/> or using <see cref="TextType.Markdown"/>, 
+    /// our proprietary textual markup that's just different enough from Markdown to frustrate you.
+    /// </summary>
+    public class TextObject : IContextElement
+    {
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum TextType
+        {
+            [EnumMember(Value = "plain_text")]
+            PlainText,
+
+            [EnumMember(Value = "mrkdwn")]
+            Markdown
+        }
+
+        /// <summary>
+        /// The formatting to use for this text object. Can be one of <see cref="TextType.PlainText"/> or <see cref="TextType.Markdown"/>.
+        /// </summary>
+        public TextType Type { get; set; }
+        /// <summary>
+        /// The text for the block. This field accepts any of the standard text formatting markup when type is <see cref="TextType.Markdown"/>.
+        /// 
+        /// https://api.slack.com/messaging/composing/formatting
+        /// </summary>
+        public string Text { get; set; }
+        /// <summary>
+        /// Indicates whether emojis in a text field should be escaped into the colon emoji format. This field is only usable when type is <see cref="TextType.PlainText"/>.
+        /// </summary>
+        public bool Emoji { get; set; }
+        /// <summary>
+        /// When set to false (as is default) URLs will be auto-converted into links, conversation names will be link-ified, and certain mentions will be automatically parsed. 
+        /// https://api.slack.com/messaging/composing/formatting#automatic-parsing
+        /// 
+        /// Using a value of true will skip any preprocessing of this nature, although you can still include manual parsing strings. This field is only usable when type is <see cref="TextType.Markdown"/>.
+        /// https://api.slack.com/messaging/composing/formatting#advanced
+        /// </summary>
+        public bool Verbatim { get; set; }
+
+        public bool ShouldSerializeEmoji()
+        {
+            return Type == TextType.PlainText;
+        }
+
+        public bool ShouldSerializeVerbatim()
+        {
+            return Type == TextType.Markdown;
+        }
+    }
+}

--- a/src/Slack.Webhooks/Elements/TextObject.cs
+++ b/src/Slack.Webhooks/Elements/TextObject.cs
@@ -45,6 +45,21 @@ namespace Slack.Webhooks.Elements
         /// </summary>
         public bool Verbatim { get; set; }
 
+        /// <summary>
+        /// Create a new instance of <see cref="TextObject"/>.
+        /// </summary>
+        public TextObject()
+        {
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="TextObject"/> with an initial Text.
+        /// </summary>
+        public TextObject(string text)
+        {
+            Text = text;
+        }
+
         public bool ShouldSerializeEmoji()
         {
             return Type == TextType.PlainText;

--- a/src/Slack.Webhooks/Enums.cs
+++ b/src/Slack.Webhooks/Enums.cs
@@ -47,4 +47,63 @@ namespace Slack.Webhooks
         [EnumMember(Value = "select")]
         Select
     }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum BlockType
+    {
+        [EnumMember(Value = "divider")]
+        Divider = 1,
+        [EnumMember(Value = "image")]
+        Image = 2,
+        [EnumMember(Value = "text")]
+        Text = 3,
+        [EnumMember(Value = "section")]
+        Section = 4,
+        [EnumMember(Value = "context")]
+        Context = 5,
+        [EnumMember(Value = "file")]
+        File = 6,
+        [EnumMember(Value = "actions")]
+        Actions = 7,
+        [EnumMember(Value = "input")]
+        Input = 8
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum ElementType
+    {
+        Unknown = 0,
+        [EnumMember(Value = "button")]
+        Button = 1,
+        [EnumMember(Value = "datepicker")]
+        DatePicker = 2,
+        [EnumMember(Value = "image")]
+        Image = 3,
+        [EnumMember(Value = "multi_static_select")]
+        MultiSelectStatic = 4,
+        [EnumMember(Value = "multi_external_select")]
+        MultiSelectExternal = 5,
+        [EnumMember(Value = "multi_users_select")]
+        MultiSelectUsers = 6,
+        [EnumMember(Value = "multi_conversations_select")]
+        MultiSelectConversations = 7,
+        [EnumMember(Value = "multi_channels_select")]
+        MultiSelectChannels = 8,
+        [EnumMember(Value = "overflow")]
+        Overflow = 9,
+        [EnumMember(Value = "plain_text_input")]
+        PlainTextInput = 10,
+        [EnumMember(Value = "radio_buttons")]
+        RadioButtons = 11,
+        [EnumMember(Value = "static_select")]
+        SelectStatic = 12,
+        [EnumMember(Value = "external_select")]
+        SelectExternal = 13,
+        [EnumMember(Value = "users_select")]
+        SelectUsers = 14,
+        [EnumMember(Value = "conversations_select")]
+        SelectConversations = 15,
+        [EnumMember(Value = "channels_select")]
+        SelectChannels = 16,
+    }
 }

--- a/src/Slack.Webhooks/Interfaces/IActionElement.cs
+++ b/src/Slack.Webhooks/Interfaces/IActionElement.cs
@@ -1,5 +1,8 @@
 namespace Slack.Webhooks.Interfaces
 {
+    /// <summary>
+    /// Encapsulates elements compatible with the <see cref="Blocks.Actions"/> block.
+    /// </summary>
     public interface IActionElement
     {
     }

--- a/src/Slack.Webhooks/Interfaces/IActionElement.cs
+++ b/src/Slack.Webhooks/Interfaces/IActionElement.cs
@@ -1,0 +1,6 @@
+namespace Slack.Webhooks.Interfaces
+{
+    public interface IActionElement
+    {
+    }
+}

--- a/src/Slack.Webhooks/Interfaces/IContextElement.cs
+++ b/src/Slack.Webhooks/Interfaces/IContextElement.cs
@@ -1,5 +1,8 @@
 namespace Slack.Webhooks.Interfaces
 {
+    /// <summary>
+    /// Encapsulates Elements compatible with the <see cref="Blocks.Context"/> block.
+    /// </summary>
     public interface IContextElement
     {
     }

--- a/src/Slack.Webhooks/Interfaces/IContextElement.cs
+++ b/src/Slack.Webhooks/Interfaces/IContextElement.cs
@@ -1,0 +1,6 @@
+namespace Slack.Webhooks.Interfaces
+{
+    public interface IContextElement
+    {
+    }
+}

--- a/src/Slack.Webhooks/Interfaces/IInputElement.cs
+++ b/src/Slack.Webhooks/Interfaces/IInputElement.cs
@@ -1,0 +1,10 @@
+namespace Slack.Webhooks.Interfaces
+{
+    /// <summary>
+    /// Encapsulates elements compatible with the <see cref="Blocks.Input"/> block.
+    /// </summary>
+    public interface IInputElement
+    {
+         
+    }
+}

--- a/src/Slack.Webhooks/SlackClient.cs
+++ b/src/Slack.Webhooks/SlackClient.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace Slack.Webhooks
 {
@@ -12,6 +14,13 @@ namespace Slack.Webhooks
         private readonly Uri _webhookUri;
         private const string POST_SUCCESS = "ok";
         private int _timeout = 100;
+
+        private static readonly DefaultContractResolver resolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() };
+        private static readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
+        {
+            ContractResolver = resolver,
+            NullValueHandling = NullValueHandling.Ignore
+        };
 
         /// <summary>
         /// Returns the current Timeout value.
@@ -55,6 +64,26 @@ namespace Slack.Webhooks
                 var content = await response.Content.ReadAsStringAsync();
                 return content.Equals(POST_SUCCESS, StringComparison.OrdinalIgnoreCase);
             }
+        }
+
+        /// <summary>
+        /// Deserialize SlackMessage from a JSON string
+        /// </summary>
+        /// <param name="json">string containing serialized JSON</param>
+        /// <returns>SlackMessage</returns>
+        public static SlackMessage DeserializeObject(string json)
+        {
+            return JsonConvert.DeserializeObject<SlackMessage>(json, serializerSettings);
+        }
+
+        /// <summary>
+        /// Serialize SlackMessage to a JSON string
+        /// </summary>
+        /// <param name="json">An instance of SlackMessage</param>
+        /// <returns>string containing serialized JSON</returns>
+        public static string SerializeObject(object obj)
+        {
+            return JsonConvert.SerializeObject(obj, serializerSettings);
         }
 
         public void Dispose()

--- a/src/Slack.Webhooks/SlackMessage.cs
+++ b/src/Slack.Webhooks/SlackMessage.cs
@@ -10,13 +10,6 @@ namespace Slack.Webhooks
     /// </summary>
     public class SlackMessage
     {
-        private static readonly DefaultContractResolver resolver = new DefaultContractResolver { NamingStrategy = new SnakeCaseNamingStrategy() };
-        private static readonly JsonSerializerSettings serializerSettings = new JsonSerializerSettings
-        {
-            ContractResolver = resolver,
-            NullValueHandling = NullValueHandling.Ignore
-        };
-
         private bool _markdown = true;
         /// <summary>
         /// This is the text that will be posted to the channel
@@ -43,11 +36,11 @@ namespace Slack.Webhooks
         /// </summary>
         public string Username { get; set; }
         /// <summary>
-        /// Optional emoji displayed with the message
+        /// Optional <see cref="Emoji"/> displayed with the message
         /// </summary>
         public string IconEmoji { get; set; }
         /// <summary>
-        /// Optional url for icon displayed with the message
+        /// Optional <see cref="Uri"/> for icon displayed with the message
         /// </summary>
         public Uri IconUrl { get; set; }
         /// <summary>
@@ -74,7 +67,7 @@ namespace Slack.Webhooks
         /// </summary>
         public bool LinkNames { get; set; }
         /// <summary>
-        /// Parse mode <see cref="ParseMode"/>
+        /// Set the message <see cref="ParseMode"/>
         /// </summary>
         public ParseMode Parse { get; set; }
         /// <summary>
@@ -87,6 +80,21 @@ namespace Slack.Webhooks
         /// </summary>
         public List<SlackAttachment> Attachments { get; set; }
 
+        /// <summary>
+        /// Optional collection of <see cref="Block"/>
+        /// </summary>
+        /// <seealso cref="Actions" />
+        /// <seealso cref="Context" />
+        /// <seealso cref="Divider" />
+        /// <seealso cref="File" />
+        /// <seealso cref="Image" />
+        /// <seealso cref="Input" />
+        /// <seealso cref="Section" />
+        public List<Block> Blocks { get; set; }
+
+        /// <summary>
+        /// Create a clone of this <see cref="SlackMessage"/> overriding the channel if provided
+        /// </summary>
         public SlackMessage Clone(string newChannel = null)
         {
             return new SlackMessage()
@@ -116,17 +124,7 @@ namespace Slack.Webhooks
         /// <returns>JSON formatted string</returns>
         public string AsJson()
         {
-            return JsonConvert.SerializeObject(this, serializerSettings);
-        }
-
-        /// <summary>
-        /// Deserialize SlackMessage from a JSON string
-        /// </summary>
-        /// <param name="json">string containing serialized JSON</param>
-        /// <returns>SlackMessage</returns>
-        public static SlackMessage FromJson(string json)
-        {
-            return JsonConvert.DeserializeObject<SlackMessage>(json, serializerSettings);
+            return SlackClient.SerializeObject(this);
         }
     }
 }


### PR DESCRIPTION
Updatine SlackMessage to be capable of sending Blocks/Elements as defined in the BlockKit documentation:

https://api.slack.com/block-kit