### PR TITLE
Post as app apis

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - feature/*
       - hotfix/*
-      - release/*
+      - master
     tags:
       - v*
   pull_request:
@@ -33,4 +33,3 @@ jobs:
         with:
           name: ${{ steps.build.outputs.nupkg_name }}
           path: ${{ steps.build.outputs.nupkg }}
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: windows-latest
     name: Dotnet build
     steps:
-      - uses: actions/checkout@master
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v2
+        - run: |
+            git fetch --prune --unshallow
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,8 @@ jobs:
     name: Dotnet build
     steps:
       - uses: actions/checkout@master
-
-      - name: Branchy Branchy
-        run: |
-          git checkout master
-          echo "${{ github.ref }}" | sed "s/refs\/\(heads\|tags\)\///" | sed "s/refs\/pull\/\([0-9]*\)\/merge/refs\/remotes\/pull\/\1\/merge/" | xargs git checkout
-          git checkout ${{ github.sha }}
-        shell: cmd
+        with:
+          fetch-depth: 0
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
     name: Dotnet build
     steps:
       - uses: actions/checkout@v2
-        - run: |
-            git fetch --prune --unshallow
+      - run: |
+          git fetch --prune --unshallow
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         shell: pwsh
         id: build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NUGET_TOKEN: ${{ secrets.NugetKey }}
       - name: Add artifacts
         uses: actions/upload-artifact@v1

--- a/build.cake
+++ b/build.cake
@@ -23,7 +23,8 @@ var isGitHubAction = !string.IsNullOrWhiteSpace(EnvironmentVariable("GITHUB_ACTI
 var githubEventName = EnvironmentVariable("GITHUB_EVENT_NAME");
 var githubRef = EnvironmentVariable("GITHUB_REF");
 var githubBaseRef = EnvironmentVariable("GITHUB_BASE_REF");
-var isTag = githubEventName == "push" && githubRef.StartsWith("refs/tags/v") && githubBaseRef == "refs/heads/master";
+var isPullRequest = githubEventName == "pull_request";
+var isTag = githubEventName == "push" && githubRef.StartsWith("refs/tags/v");
 
 Information($"EventName: {githubEventName}, Ref: {githubRef}, BaseRef: {githubBaseRef}, IsTag: {isTag}, IsGithubAction: {isGitHubAction}");
 
@@ -97,9 +98,9 @@ Task("DeployGPR")
    .IsDependentOn("Pack")
    .Does(() =>
 {
-   var isMaster = githubBaseRef == "refs/heads/master";
-   if(isGitHubAction && isMaster)
+   if(isGitHubAction && !isPullRequest)
    {
+      Information($"DeployGPR. IsGitHubAction: {isGitHubAction}, IsPullRequest: {isPullRequest}");
       var settings = new NuGetSourcesSettings
                               {
                                     UserName = "mrb0nj",
@@ -114,7 +115,7 @@ Task("DeployGPR")
    }
    else
    {
-       Information($"Skipping DeployGPR. IsGitHubAction: {isGitHubAction}");
+       Information($"Skipping DeployGPR. IsGitHubAction: {isGitHubAction}, IsPullRequest: {isPullRequest}");
    }
 });
 
@@ -124,6 +125,7 @@ Task("DeployNuGet")
 {
    if(isGitHubAction && isTag)
    {
+      Information($"DeployNuget. IsGitHubAction: {isGitHubAction}, IsTag: {isTag}");
       var settings = new NuGetPushSettings
       {
          Source = "https://api.nuget.org/v3/index.json",

--- a/src/Slack.Webhooks/SlackResponse.cs
+++ b/src/Slack.Webhooks/SlackResponse.cs
@@ -1,0 +1,20 @@
+namespace Slack.Webhooks
+{
+    public class SlackResponse
+    {
+        public bool ok { get; set; }
+        public string channel { get; set; }
+        public string ts { get; set; }
+        public Message message { get; set; }
+    }
+
+    public class Message
+    {
+        public string type { get; set; }
+        public string subtype { get; set; }
+        public string text { get; set; }
+        public string ts { get; set; }
+        public string username { get; set; }
+        public string bot_id { get; set; }
+    }
+}

--- a/src/Slack.Webhooks/SlackResponse.cs
+++ b/src/Slack.Webhooks/SlackResponse.cs
@@ -1,20 +1,40 @@
+using Newtonsoft.Json;
+
 namespace Slack.Webhooks
 {
     public class SlackResponse
     {
-        public bool ok { get; set; }
-        public string channel { get; set; }
-        public string ts { get; set; }
-        public Message message { get; set; }
+        [JsonProperty(PropertyName = "ok")]
+        public bool Ok { get; set; }
+        
+        [JsonProperty(PropertyName = "channel")]
+        public string Channel { get; set; }
+        
+        [JsonProperty(PropertyName = "ts")]
+        public string ThreadId { get; set; }
+        
+        [JsonProperty(PropertyName = "message")]
+        public Message Message { get; set; }
     }
 
     public class Message
     {
-        public string type { get; set; }
-        public string subtype { get; set; }
-        public string text { get; set; }
-        public string ts { get; set; }
-        public string username { get; set; }
-        public string bot_id { get; set; }
+        [JsonProperty(PropertyName = "type")]
+        public string Type { get; set; }
+        
+        [JsonProperty(PropertyName = "subtype")]
+        public string SubType { get; set; }
+        
+        [JsonProperty(PropertyName = "text")]
+        public string Text { get; set; }
+        
+        [JsonProperty(PropertyName = "ts")]
+        public string ThreadId { get; set; }
+        
+        [JsonProperty(PropertyName = "username")]
+        public string Username { get; set; }
+        
+        [JsonProperty(PropertyName = "bot_id")]
+        public string BotId { get; set; }
     }
 }


### PR DESCRIPTION
This adds a method to post messages as a registered slack app that allows threaded messages.

I originally wrote a `ctor` that took a authorizationToken as value instead of a webhook but the `ctor` signatures were the same so BANG!

To have a threaded app and use the full api I think you have to be a registered app with a token.  However it all seemed to just work:

<img width="286" alt="Screenshot 2020-02-17 at 20 29 29" src="https://user-images.githubusercontent.com/105126/74684581-369e3800-51c4-11ea-8a41-bd8dc017adc9.png">

Not sure if you want this PR as is or even want the extra API but here you go 😄 