### PR TITLE
Using JsonPropertyAttribute to enforce MultiLine serialization

### DIFF
--- a/src/Slack.Webhooks.Tests/PlainTextInputElementFixtures.cs
+++ b/src/Slack.Webhooks.Tests/PlainTextInputElementFixtures.cs
@@ -70,7 +70,7 @@ namespace Slack.Webhooks.Tests
             var payload = SlackClient.SerializeObject(input);
 
             // assert
-            payload.Should().Contain("\"multi_line\":true");
+            payload.Should().Contain("\"multiline\":true");
         }
 
         [Fact]

--- a/src/Slack.Webhooks/Elements/PlainTextInput.cs
+++ b/src/Slack.Webhooks/Elements/PlainTextInput.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using Slack.Webhooks.Interfaces;
 
 namespace Slack.Webhooks.Elements
@@ -31,6 +32,7 @@ namespace Slack.Webhooks.Elements
         /// <summary>
         /// Indicates whether the input will be a single line (false) or a larger textarea (true). Defaults to false.
         /// </summary>
+        [JsonProperty("multiline")]
         public bool MultiLine { get; set; }
         /// <summary>
         /// The minimum length of input that the user must provide. If the user provides less, they will receive an error. Maximum value is 3000.


### PR DESCRIPTION
Fixes #100 